### PR TITLE
SonarCloud Action의 경우

### DIFF
--- a/.github/workflows/SonarCloud_PR.yml
+++ b/.github/workflows/SonarCloud_PR.yml
@@ -1,0 +1,21 @@
+name: SonarCloud Scan for PR
+
+on:
+  pull_request:
+    branches:
+      - master
+      
+jobs:
+  sonarCloudTrigger:
+    name: SonarCloud Trigger
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Build Files for Scanning
+      run:
+      
+    - name: SonarCloud Scan
+      uses: sonarsource/sonarcloud-github-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/SonarCloud_PR.yml
+++ b/.github/workflows/SonarCloud_PR.yml
@@ -12,8 +12,13 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build Files for Scanning
-      run:
-      
+      run: |
+        cd Main_Server
+        npm install && npm run build
+        npm run copy-view
+        cd ../Layout
+        npm install
+           
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master
       env:

--- a/.github/workflows/sonar-project.properties
+++ b/.github/workflows/sonar-project.properties
@@ -1,0 +1,14 @@
+# must be unique in a given SonarQube instance
+sonar.projectKey=s5kywa1k3r_Product
+# this is the name displayed in the SonarQube UI
+sonar.projectName=s5kywa1k3r_Product
+sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+# Since SonarQube 4.2, this property is optional if sonar.modules is set. 
+# If not set, SonarQube starts looking for source code from the directory containing 
+# the sonar-project.properties file.
+sonar.sources=../../
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
  EVENT_ACTION=$(jq -r ".action" "${GITHUB_EVENT_PATH}")
  if [[ "${EVENT_ACTION}" != "opened" ]]; then
	  echo "No need to run analysis. It is already triggered by the push event."
	  exit 78
  fi
fi

Event가 pull_request가 open일때만 적용됨